### PR TITLE
Adding 'parts' property to custom error params

### DIFF
--- a/lib/argument.ts
+++ b/lib/argument.ts
@@ -31,6 +31,7 @@ export default class Argument {
             default:
                 throw new CommandpostError({
                     message: `unsupported format: ${arg}`,
+                    parts: [arg],
                     reason: ErrorReason.UnsupportedFormatArgument,
                     params: {
                         origin: this,
@@ -67,7 +68,8 @@ export default class Argument {
     parse(opts: any, args: string[]): string[] {
         if (this.required && this.variadic && args.length === 0) {
             throw new CommandpostError({
-                message: `${this.name} is required more than 1 argument`,
+                message: `${this.name} requires more than one argument`,
+                parts: [this.name],
                 reason: ErrorReason.ArgumentsRequired,
                 params: {
                     origin: this,
@@ -86,6 +88,7 @@ export default class Argument {
             throw new CommandpostError({
                 message: `${this.name} is required`,
                 reason: ErrorReason.ArgumentRequired,
+                parts: [this.name],
                 params: {
                     origin: this,
                     opts,

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -124,6 +124,7 @@ export default class Command<Opt, Arg> {
         this.args = args.map(argStr => {
             if (findVariadic) {
                 throw new CommandpostError({
+                    parts: [argStr],
                     message: "parameter can not placed after variadic parameter",
                     reason: ErrorReason.ParameterCantPlacedAfterVariadic,
                 });
@@ -131,6 +132,7 @@ export default class Command<Opt, Arg> {
             let arg = new Argument(argStr);
             if (arg.required && findOptional) {
                 throw new CommandpostError({
+                    parts: [argStr],
                     message: "parameter can not placed after variadic parameter",
                     reason: ErrorReason.ParameterCannPlacedAfterOptional,
                 });
@@ -364,6 +366,7 @@ export default class Command<Opt, Arg> {
             throw new CommandpostError({
                 message: errMsg,
                 reason: ErrorReason.UnknownOption,
+                parts: this.unknownOptions,
                 params: {
                     origin: this,
                     args,

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -7,6 +7,7 @@ import Option from "./option";
 export interface ErrorParameters {
     message?: string;
     reason: ErrorReason;
+    parts: string[];
     params?:
     { origin: Argument; arg: string; } |
     { origin: Argument; opts: any; args: string[]; } |

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,9 +13,9 @@ try {
 import Command from "./command";
 import Option from "./option";
 import Argument from "./argument";
-import { CommandpostError, ErrorReason } from "./error";
+export { CommandpostError, ErrorReason } from "./error";
 
-export { Command, Option, Argument, CommandpostError, ErrorReason };
+export { Command, Option, Argument };
 
 /**
  * Create new top level command.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,8 +13,9 @@ try {
 import Command from "./command";
 import Option from "./option";
 import Argument from "./argument";
+import { CommandpostError, ErrorReason } from "./error";
 
-export { Command, Option, Argument };
+export { Command, Option, Argument, CommandpostError, ErrorReason };
 
 /**
  * Create new top level command.

--- a/lib/option.ts
+++ b/lib/option.ts
@@ -91,6 +91,7 @@ export default class Option {
             throw new CommandpostError({
                 message: `${args[0]} is not match ${this.short} or ${this.long}`,
                 reason: ErrorReason.OptionNameMismatch,
+                parts: [args[0]],
                 params: {
                     option: this,
                     opts,
@@ -105,6 +106,7 @@ export default class Option {
                 throw new CommandpostError({
                     message: `${args[0]} is required parameter value`,
                     reason: ErrorReason.OptionValueRequired,
+                    parts: [args[0]],
                     params: {
                         option: this,
                         opts,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,14 +10,14 @@
             "node",
             "mocha"
 		],
-		"strict": true,
+        "strict": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
-        "stripInternal": true,
+        "stripInternal": false,
         "skipDefaultLibCheck": true,
         "skipLibCheck": false,
         "rootDir": ".",
@@ -28,7 +28,8 @@
         "newLine": "LF",
         "noEmitOnError": true,
         "inlineSources": true,
-        "listEmittedFiles": false
+        "listEmittedFiles": false,
+        "preserveConstEnums": true,
     },
     "include": [
         "lib/**/*.ts",


### PR DESCRIPTION
@vvakame Regarding https://github.com/vvakame/commandpost/issues/6. That was pretty close to what I was thinking. I wanted access to the specific parts that were causing the error, though. So, I added those, and added a couple classes to the index.ts exports.

That allows me to adjust error messages in my dependent code whenever needed, like so:

```typescript
export let cmdErrors: { [key: string]: (err: CommandpostError) => string } = {};
cmdErrors[r.ArgumentRequired] = (err) => `Argument ${err.params.parts[0]} is required.`;
cmdErrors[r.ArgumentsRequired] = (err) => `Arguments ${err.params.parts.join(', ')} are required.`;
cmdErrors[r.OptionNameMismatch] = (err) => `Option name ${err.params.parts[0]} doesn't match.`;
cmdErrors[r.OptionValueRequired] = (err) => `Value required for option ${err.params.parts[0]}.`;
cmdErrors[r.ParameterCannPlacedAfterOptional] = (err) => `Parameter ${err.params.parts[0]} cannot be placed after optional parameter.`;
cmdErrors[r.ParameterCantPlacedAfterVariadic] = (err) => `Parameter ${err.params.parts[0]} cannot be placed after optional parameter.`;
cmdErrors[r.UnknownOption] = (err) => `Option(s) ${err.params.parts.join(', ')} are unknown.`;
cmdErrors[r.UnsupportedFormatArgument] = (err) => `Internal error. Unsupported format: ${err.params.parts[0]}.`;
```