### PR TITLE
Include command helptext for invalid option

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -374,7 +374,7 @@ export default class Command<Opt, Arg> {
         if (this.unknownOptions.length !== 0 && !allowUnknownOption) {
             let errMsg = "unknown option";
             errMsg += this.unknownOptions.length === 1 ? " " : "s ";
-            errMsg += this.unknownOptions.join(", ") + "\n";
+            errMsg += this.unknownOptions.join(", ") + "\n\n";
             errMsg += this.helpText();
             throw new CommandpostError({
                 message: errMsg,

--- a/src/command.ts
+++ b/src/command.ts
@@ -355,7 +355,20 @@ export default class Command<Opt, Arg> {
 
         this._rawArgs = target.slice(0);
         this._args = this._normalize(target);
-        this._rest = this._parseOptions(this._args);
+
+        try {
+            this._rest = this._parseOptions(this._args);
+        } catch (error) {
+            let errMsg = error.message + "\n\n";
+            errMsg += this.helpText();
+            throw new CommandpostError({
+                message: errMsg,
+                reason: error.reason,
+                parts: error.parts,
+                params: error.params,
+            });
+        }
+
         let cmds = this._getAncestorsAndMe();
         let allowUnknownOption = cmds.reverse().map(cmd => cmd._allowUnknownOption).filter(allowUnknownOption => typeof allowUnknownOption !== "undefined")[0];
         if (this.unknownOptions.length !== 0 && !allowUnknownOption) {


### PR DESCRIPTION
Didn't know what I was thinking in #13, this is actually much more easily. 
In my opinion we need to display the command helptext if parsing of a command option fails.

Meaning display the whole helptext instead just `-x is required parameter value`.